### PR TITLE
chore(renovate): add full configuration and guarded automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "dependencyDashboard": true,
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 10,
+  "rebaseWhen": "conflicted",
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Automerge safe non-major updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Do not automerge major updates",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "labels": [
+        "major-update"
+      ]
+    },
+    {
+      "description": "Keep go directive in go.mod updated",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
+      "rangeStrategy": "bump",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Replace the default Renovate onboarding config with a full repository policy and enable guarded automerge behavior.

### What is configured

- `config:recommended` baseline
- semantic commit format for Renovate PRs
- pinning for GitHub Action digests
- dependency dashboard
- controlled PR rate (`prHourlyLimit`, `prConcurrentLimit`)
- `gomodTidy` post-update
- weekly lock-file maintenance
- guarded automerge for non-major updates (`minor`, `patch`, `digest`, `pin`)
- explicit no-automerge policy for `major` updates
- explicit rule to bump `go` directive in `go.mod`

### CI and branch protections check

Branch protection on `master` already requires checks:
- `Lint`
- `Test`
- `Build`
- `Verify`
- `E2E Tests`

Repository setting `allow_auto_merge` is enabled.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (describe): Renovate policy setup

## Checklist

- [x] Renovate config validates as JSON
- [x] Policy limits major updates from automerge
- [x] Branch required checks confirmed
