### PR TITLE
ci: pin golangci-lint (+ renovate customManager) and fix goconst

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           args: --timeout=5m
 
   markdown-lint:

--- a/api/transmission/client_test.go
+++ b/api/transmission/client_test.go
@@ -12,6 +12,13 @@ import (
 
 const testMetainfo = "dGVzdA==" // base64 "test"
 
+// testFieldID and testFieldName are the torrent fields requested across
+// the get tests.
+const (
+	testFieldID   = "id"
+	testFieldName = "name"
+)
+
 //go:embed testdata/responses/session-get.json
 var sessionGetResponse string
 
@@ -307,7 +314,7 @@ func TestTorrentGet(t *testing.T) {
 		client, err := newTestClient(mock)
 		require.NoError(t, err)
 
-		result, err := client.TorrentGet(context.Background(), []string{"id", "name"}, nil)
+		result, err := client.TorrentGet(context.Background(), []string{testFieldID, testFieldName}, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, result.Torrents)
 	})
@@ -327,7 +334,7 @@ func TestTorrentGet(t *testing.T) {
 		client, err := newTestClient(mock)
 		require.NoError(t, err)
 
-		result, err := client.TorrentGet(context.Background(), []string{"id", "name"}, []int64{1})
+		result, err := client.TorrentGet(context.Background(), []string{testFieldID, testFieldName}, []int64{1})
 		require.NoError(t, err)
 		assert.NotEmpty(t, result.Torrents)
 	})
@@ -346,7 +353,7 @@ func TestTorrentGet(t *testing.T) {
 		client, err := newTestClient(mock)
 		require.NoError(t, err)
 
-		result, err := client.TorrentGet(context.Background(), []string{"id", "name"}, []int64{99999})
+		result, err := client.TorrentGet(context.Background(), []string{testFieldID, testFieldName}, []int64{99999})
 		require.NoError(t, err)
 		assert.Empty(t, result.Torrents)
 	})
@@ -365,7 +372,7 @@ func TestTorrentGet(t *testing.T) {
 		client, err := newTestClient(mock)
 		require.NoError(t, err)
 
-		result, err := client.TorrentGetRecentlyActive(context.Background(), []string{"id", "name"})
+		result, err := client.TorrentGetRecentlyActive(context.Background(), []string{testFieldID, testFieldName})
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 	})

--- a/api/transmission/mock_test.go
+++ b/api/transmission/mock_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/ymz-ncnk/mok"
 )
 
+// testSessionID is the CSRF session id used across the mock responses.
+const testSessionID = "test-session-id"
+
 // RoundTripperMock is a mock for http.RoundTripper.
 type RoundTripperMock struct {
 	mock *mok.Mock
@@ -48,8 +51,8 @@ func jsonResponse(body string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header: http.Header{
-			"Content-Type":              []string{"application/json"},
-			"X-Transmission-Session-Id": []string{"test-session-id"},
+			"Content-Type":  []string{"application/json"},
+			sessionIDHeader: []string{testSessionID},
 		},
 		Body: io.NopCloser(bytes.NewBufferString(body)),
 	}
@@ -60,7 +63,7 @@ func sessionIDResponse() *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusConflict,
 		Header: http.Header{
-			"X-Transmission-Session-Id": []string{"test-session-id"},
+			sessionIDHeader: []string{testSessionID},
 		},
 		Body: io.NopCloser(bytes.NewBufferString("")),
 	}

--- a/api/transmission/transport.go
+++ b/api/transmission/transport.go
@@ -19,6 +19,11 @@ const (
 
 	// contentType is the content type for JSON-RPC requests.
 	contentType = "application/json"
+
+	// Log field keys for the structured request/response trace.
+	logKeyMethod     = "method"
+	logKeyError      = "error"
+	logKeyDurationMS = "duration_ms"
 )
 
 // rpcRequest represents a JSON-RPC request to Transmission.
@@ -79,7 +84,7 @@ func (t *httpTransport) Do(ctx context.Context, method string, args any) (json.R
 		return nil, err
 	}
 
-	t.logger.Debug("sending RPC request", Field{Key: "method", Value: method}, Field{Key: "tag", Value: tag})
+	t.logger.Debug("sending RPC request", Field{Key: logKeyMethod, Value: method}, Field{Key: "tag", Value: tag})
 
 	start := time.Now()
 
@@ -99,7 +104,7 @@ func (t *httpTransport) marshalRequest(method string, args any, tag int64) ([]by
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		t.logger.Error("failed to marshal request",
-			Field{Key: "method", Value: method}, Field{Key: "error", Value: err.Error()})
+			Field{Key: logKeyMethod, Value: method}, Field{Key: logKeyError, Value: err.Error()})
 
 		return nil, errors.Wrap(err, ErrMarshalRequest.Error())
 	}
@@ -111,7 +116,7 @@ func (t *httpTransport) marshalRequest(method string, args any, tag int64) ([]by
 func (t *httpTransport) doRequestWithCSRF(ctx context.Context, method string, body []byte) (*http.Response, error) {
 	resp, err := t.doRequest(ctx, body)
 	if err != nil {
-		t.logger.Error("HTTP request failed", Field{Key: "method", Value: method}, Field{Key: "error", Value: err.Error()})
+		t.logger.Error("HTTP request failed", Field{Key: logKeyMethod, Value: method}, Field{Key: logKeyError, Value: err.Error()})
 
 		return nil, err
 	}
@@ -125,18 +130,18 @@ func (t *httpTransport) doRequestWithCSRF(ctx context.Context, method string, bo
 	_ = resp.Body.Close()
 
 	if sessionID == "" {
-		t.logger.Error("CSRF session ID missing in 409 response", Field{Key: "method", Value: method})
+		t.logger.Error("CSRF session ID missing in 409 response", Field{Key: logKeyMethod, Value: method})
 
 		return nil, errors.WithStack(ErrCSRFMissing)
 	}
 
-	t.logger.Debug("received new CSRF session ID, retrying request", Field{Key: "method", Value: method})
+	t.logger.Debug("received new CSRF session ID, retrying request", Field{Key: logKeyMethod, Value: method})
 	t.sessionID.Store(sessionID)
 
 	resp, err = t.doRequest(ctx, body)
 	if err != nil {
 		t.logger.Error("HTTP request failed after CSRF retry",
-			Field{Key: "method", Value: method}, Field{Key: "error", Value: err.Error()})
+			Field{Key: logKeyMethod, Value: method}, Field{Key: logKeyError, Value: err.Error()})
 
 		return nil, err
 	}
@@ -150,8 +155,8 @@ func (t *httpTransport) handleResponse(resp *http.Response, method string, start
 
 	if resp.StatusCode != http.StatusOK {
 		t.logger.Error("unexpected HTTP status",
-			Field{Key: "method", Value: method}, Field{Key: "status", Value: resp.StatusCode},
-			Field{Key: "duration_ms", Value: duration.Milliseconds()})
+			Field{Key: logKeyMethod, Value: method}, Field{Key: "status", Value: resp.StatusCode},
+			Field{Key: logKeyDurationMS, Value: duration.Milliseconds()})
 
 		return nil, NewHTTPError(resp.StatusCode, resp.Status)
 	}
@@ -159,7 +164,7 @@ func (t *httpTransport) handleResponse(resp *http.Response, method string, start
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.logger.Error("failed to read response body",
-			Field{Key: "method", Value: method}, Field{Key: "error", Value: err.Error()})
+			Field{Key: logKeyMethod, Value: method}, Field{Key: logKeyError, Value: err.Error()})
 
 		return nil, errors.Wrap(err, ErrReadResponse.Error())
 	}
@@ -167,20 +172,20 @@ func (t *httpTransport) handleResponse(resp *http.Response, method string, start
 	var rpcResp rpcResponse
 	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
 		t.logger.Error("failed to unmarshal response",
-			Field{Key: "method", Value: method}, Field{Key: "error", Value: err.Error()})
+			Field{Key: logKeyMethod, Value: method}, Field{Key: logKeyError, Value: err.Error()})
 
 		return nil, errors.Wrap(err, ErrUnmarshalResponse.Error())
 	}
 
 	if rpcResp.Result != "success" {
-		t.logger.Error("RPC error", Field{Key: "method", Value: method},
-			Field{Key: "result", Value: rpcResp.Result}, Field{Key: "duration_ms", Value: duration.Milliseconds()})
+		t.logger.Error("RPC error", Field{Key: logKeyMethod, Value: method},
+			Field{Key: "result", Value: rpcResp.Result}, Field{Key: logKeyDurationMS, Value: duration.Milliseconds()})
 
 		return nil, NewRPCError(rpcResp.Result)
 	}
 
 	t.logger.Debug("RPC request completed",
-		Field{Key: "method", Value: method}, Field{Key: "duration_ms", Value: duration.Milliseconds()})
+		Field{Key: logKeyMethod, Value: method}, Field{Key: logKeyDurationMS, Value: duration.Milliseconds()})
 
 	return rpcResp.Arguments, nil
 }

--- a/renovate.json
+++ b/renovate.json
@@ -53,5 +53,15 @@
       "automergeType": "pr",
       "platformAutomerge": true
     }
+  ],
+  "customManagers": [
+    {
+      "description": "Bump tool versions annotated with a renovate comment in workflows",
+      "customType": "regex",
+      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*)\\n.*?[\"']?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)[\"']?"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## What

Resolve every `goconst` finding the Lint check reports (golangci-lint resolves `latest` → v2.12.2): hoist repeated string literals to named constants.

- `transport.go` — the structured-log field keys `method`/`error`/`duration_ms`.
- tests — the session-id header (reusing the existing `sessionIDHeader`), the `test-session-id` fixture, and the `id`/`name` torrent fields.

## Why

The `Lint` job is a required check and was red on every dependency PR because these findings live in code already on `master` — blocking all renovate automerges. This makes `Lint` green again. Pure constant extraction, no behavioral change.

## Verification

- `golangci-lint run` (v2.12.2) — zero issues.
- `go build ./...` / `go test ./...` — clean.